### PR TITLE
Explicitly declare service type - fails otherwise on CentOS 6.4 in some ...

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -52,6 +52,7 @@ define selenium::config(
     hasstatus  => true,
     hasrestart => true,
     enable     => true,
+    provider   => 'init',
   }
 
 }


### PR DESCRIPTION
I was trying to use your module for my CentOS 6.4 installation, but somehow Puppet tried to start it via `service seleniumserver start` instead. Since your implementation uses the init provider explicitly, this change got it to work for me instead of relying on Puppet's auto-detection.
