### PR TITLE
Refresh service if the options are changed

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -46,7 +46,7 @@ define selenium::config(
     group   => 'root',
     mode    => '0755',
     content => template("${module_name}/init.d/selenium.erb"),
-  } ->
+  } ~>
   service { $prog:
     ensure     => running,
     hasstatus  => true,


### PR DESCRIPTION
I was experimenting with different versions of selenium server, and it turns out that upon changing the options, the new `.jar` is downloaded but not used upon reapplying the puppet script.

I have changed the require arrow to a notify one, so that the service gets notified (and thus refreshes) if the init file changes.
