### PR TITLE
ensure selenium log folder is writable by its owner

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,6 +125,7 @@ class selenium(
 
   file { $log_path:
     ensure => directory,
+    mode => 0755,
   }
 
   file { '/var/log/selenium':


### PR DESCRIPTION
our default mode is 0444 - which means selenium hub & node won't start.. because they can't write to log folder as user selenium.

I tested this fix, it works here.
