### PR TITLE
add support for systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,9 @@ Timeout to download of the package.
 ```puppet
 # defaults
 class { 'selenium::server':
-  display => ':0',
-  options => '-Dwebdriver.enable.native.events=1',
+  display    => ':0',
+  options    => '-Dwebdriver.enable.native.events=1',
+  initsystem => 'sysv',
 }
 ```
 
@@ -271,6 +272,13 @@ variable passed to Selenium Server
 
 Options passed to Selenium Server at startup.
 
+##### `initsystem`
+
+`String` defaults to: `sysv`
+
+Possible values are `systemd` and `sysv`.
+Creates and uses sysv init scripts or new systemd scripts.
+
 #### `selenium::hub`
 
 Note that by default `selenium::server` and `selenium::hub` will try to listen
@@ -279,7 +287,8 @@ on the same TCP port (`4444`) and only one of them will be able to function.
 ```puppet
 # defaults
 class { 'selenium::hub':
-  options => '-role hub',
+  options    => '-role hub',
+  initsystem => 'sysv',
 }
 ```
 
@@ -288,6 +297,13 @@ class { 'selenium::hub':
 `String` defaults to: `-role hub`
 
 Options passed to Selenium Server Hub at startup.
+
+##### `initsystem`
+
+`String` defaults to: `sysv`
+
+Possible values are `systemd` and `sysv`.
+Creates and uses sysv init scripts or new systemd scripts.
 
 #### `selenium::node`
 
@@ -318,6 +334,13 @@ Options passed to Selenium Server Node at startup.
 `String` defaults to: `http://localhost:4444/grid/register`
 
 The URL of the Selenium Server Hub to connect to.
+
+##### `initsystem`
+
+`String` defaults to: `sysv`
+
+Possible values are `systemd` and `sysv`.
+Creates and uses sysv init scripts or new systemd scripts.
 
 
 Why Another Module?
@@ -362,7 +385,7 @@ specific init scripts.
 ### Tested Platforms
 
  * el6.x
-
+ * Fedora 21
 
 Versioning
 ----------

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,7 @@ define selenium::config(
   $options      = $selenium::params::server_options,
   $java         = $selenium::params::java,
   $jar_name     = $selenium::jar_name,
+  $initsystem   = $selenium::params::initsystem,
 ) {
   validate_string($display)
   validate_string($user)
@@ -18,17 +19,43 @@ define selenium::config(
   validate_string($options)
   validate_string($java)
   validate_string($jar_name)
+  validate_re($initsystem, '^(sysv|systemd)$')
 
   # prog is the 'name' of the init.d script.
   $prog = "selenium${name}"
 
-  file { "/etc/init.d/${prog}":
-    ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0755',
-    content => template("${module_name}/init.d/selenium.erb"),
-  } ~>
+  case $initsystem {
+    'systemd' : {
+      file { "/usr/lib/systemd/system/${prog}.service":
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        content => template("${module_name}/systemd/selenium.erb"),
+        notify  => Service[$prog],
+      }
+
+      file { "/etc/${prog}.conf":
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        content => template("${module_name}/systemd/conf.erb"),
+        notify  => Service[$prog],
+      }
+    }
+    default  : {
+      file { "/etc/init.d/${prog}":
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        content => template("${module_name}/init.d/selenium.erb"),
+        notify  => Service[$prog],
+      }
+    }
+  }
+
   service { $prog:
     ensure     => running,
     hasstatus  => true,

--- a/manifests/hub.pp
+++ b/manifests/hub.pp
@@ -5,7 +5,8 @@
 #
 #
 class selenium::hub(
-  $options = $selenium::params::hub_options,
+  $options      = $selenium::params::hub_options,
+  $initsystem   = $selenium::params::initsystem,
 ) inherits selenium::params {
   validate_string($options)
 
@@ -19,6 +20,7 @@ class selenium::hub(
     install_root => $selenium::install_root,
     options      => $options,
     java         => $selenium::java,
+    initsystem   => $initsystem,
   } ->
   anchor { 'selenium::hub::end': }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,8 @@ class selenium(
   include wget
 
   user { $user:
-    gid    => $group,
+    gid         => $group,
+    managehome  => true,
   }
   group { $group:
     ensure => present,

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -5,9 +5,10 @@
 #
 #
 class selenium::node(
-  $display = $selenium::params::display,
-  $options = $selenium::params::node_options,
-  $hub     = $selenium::params::default_hub,
+  $display    = $selenium::params::display,
+  $options    = $selenium::params::node_options,
+  $hub        = $selenium::params::default_hub,
+  $initsystem = $selenium::params::initsystem,
 ) inherits selenium::params {
   validate_string($display)
   validate_string($options)
@@ -26,6 +27,7 @@ class selenium::node(
     install_root => $selenium::install_root,
     options      => $safe_options,
     java         => $selenium::java,
+    initsystem   => $initsystem,
   } ->
   anchor { 'selenium::node::end': }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class selenium::params {
   $version          = '2.42.1'
   $default_hub      = 'http://localhost:4444/grid/register'
   $download_timeout = '90'
+  $initsystem       = 'sysv'
 
   case $::osfamily {
     'redhat': {}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -5,8 +5,9 @@
 #
 #
 class selenium::server(
-  $display = $selenium::params::display,
-  $options = $selenium::params::server_options,
+  $display    = $selenium::params::display,
+  $options    = $selenium::params::server_options,
+  $initsystem = $selenium::params::initsystem,
 ) inherits selenium::params {
   validate_string($display)
   validate_string($options)
@@ -22,6 +23,7 @@ class selenium::server(
     install_root => $selenium::install_root,
     options      => $options,
     java         => $selenium::java,
+    initsystem   => $initsystem,
   } ->
   anchor { 'selenium::server::end': }
 }

--- a/templates/systemd/conf.erb
+++ b/templates/systemd/conf.erb
@@ -1,0 +1,5 @@
+# Parameters to be passed to the server when started
+SELENIUM_SERVER_ARGS="<%= @options %>"
+
+# Name of the X display to connect to when creating a new session
+DISPLAY="<%= @display %>"

--- a/templates/systemd/selenium.erb
+++ b/templates/systemd/selenium.erb
@@ -1,0 +1,12 @@
+[Unit]
+Description=Selenium Standalone Server
+After=network.target network-online.target
+
+[Service]
+EnvironmentFile=/etc/<%= @prog %>.conf
+ExecStart=/usr/bin/java -jar <%= @install_root %>/jars/<%= @jar_name %> $SELENIUM_SERVER_ARGS
+KillMode=process
+User=<%= @user %>
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This adds support for systemd.
The default behavior is to use sysv, which means that nothing will change for default configurations.
