### PR TITLE
fix travis ruby 1.8.7 runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+bundler_args: --without beaker
 rvm:
   - 1.8.7
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 bundler_args: --without beaker
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -6,17 +6,22 @@ else
   gem 'puppet', :require => false
 end
 
-gem 'rake',                   :require => false
-gem 'puppetlabs_spec_helper', :require => false
-gem 'puppet-lint',            :require => false
-gem 'puppet-syntax',          :require => false
-gem 'rspec-puppet',
-  :git => 'https://github.com/rodjek/rspec-puppet.git',
-  :ref => '6ac97993fa972a15851a73d55fe3d1c0a85172b5',
-  :require => false
-# rspec 3 spews warnings with rspec-puppet 1.0.1
-# gem 'rspec-core', '~> 2.0',   :require => false
-gem 'beaker',                  :require => false
-gem 'beaker-rspec',            :require => false
-gem 'serverspec',              :require => false
-gem 'pry',                     :require => false
+group :development do
+  gem 'rake',                   :require => false
+  gem 'puppetlabs_spec_helper', :require => false
+  gem 'puppet-lint',            :require => false
+  gem 'puppet-syntax',          :require => false
+  gem 'rspec-puppet',
+    :git => 'https://github.com/rodjek/rspec-puppet.git',
+    :ref => '6ac97993fa972a15851a73d55fe3d1c0a85172b5',
+    :require => false
+  # rspec 3 spews warnings with rspec-puppet 1.0.1
+  # gem 'rspec-core', '~> 2.0',   :require => false
+  gem 'pry',                     :require => false
+end
+
+group :beaker do
+  gem 'beaker',                  :require => false
+  gem 'beaker-rspec',            :require => false
+  gem 'serverspec',              :require => false
+end


### PR DESCRIPTION
By excluding beaker related gems that pull in deps now incompatible with
1.8.7.