### PR TITLE
Make user management optional if user is already managed elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,11 +207,23 @@ class { 'selenium':
 The name/uid of the system role account to execute the server process under and
 will have ownership of files.
 
+##### `manage_user`
+
+`Boolean` defaults to: `true`
+
+Wether or not this module should manage the system role account to execute the server process under.
+
 ##### `group`
 
 `String` defaults to: `selenium`
 
 The group/gid of the system role account and group ownership of files.
+
+##### `manage_group`
+
+`Boolean` defaults to: `true`
+
+Wether or not this module should manage the group of the system role account.
 
 ##### `install_root`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,9 @@
 #
 class selenium(
   $user               = $selenium::params::user,
+  $manage_user        = $selenium::params::manage_user,
   $group              = $selenium::params::group,
+  $manage_group       = $selenium::params::manage_group,
   $install_root       = $selenium::params::install_root,
   $java               = $selenium::params::java,
   $version            = $selenium::params::version,
@@ -25,11 +27,16 @@ class selenium(
 
   include wget
 
-  user { $user:
-    gid    => $group,
+  if $manage_user {
+    user { $user:
+      gid => $group,
+    }
   }
-  group { $group:
-    ensure => present,
+
+  if $manage_group {
+    group { $group:
+      ensure => present,
+    }
   }
 
   $jar_name     = "selenium-server-standalone-${version}.jar"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,9 @@
 class selenium::params {
   $display          = ':0'
   $user             = 'selenium'
+  $manage_user      = true
   $group            = $user
+  $manage_group     = true
   $install_root     = '/opt/selenium'
   $server_options   = '-Dwebdriver.enable.native.events=1'
   $hub_options      = '-role hub'


### PR DESCRIPTION
On a particular setup, this could cause a dependency cycle, so I made user and group management optional.