### PR TITLE
Use SLNM_JAVA variable

### DIFF
--- a/templates/init.d/selenium.erb
+++ b/templates/init.d/selenium.erb
@@ -43,7 +43,7 @@ lockfile=/var/lock/subsys/$prog
 pidfile=/var/run/${prog}.pid
 
 # pidfile must be owned by selenium user
-exec="DISPLAY=${SLNM_DISPLAY} java -jar ${SLNM_JAR} ${SLNM_OPTIONS} > ${SLNM_LOG} 2> ${SLNM_ERROR_LOG} & "'echo $!'" > ${pidfile}"
+exec="DISPLAY=${SLNM_DISPLAY} ${SLNM_JAVA} -jar ${SLNM_JAR} ${SLNM_OPTIONS} > ${SLNM_LOG} 2> ${SLNM_ERROR_LOG} & "'echo $!'" > ${pidfile}"
 
 start() {
 #    [ -x $exec ] || exit 5


### PR DESCRIPTION
There is a variable `$SLNM_JAVA` in the init.d file, but it was not used. This is needed if java bin is not in `$PATH`.