### PR TITLE
Remove hard external module dependency and allow package installation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class selenium(
   $url                = undef,
   $download_timeout   = $selenium::params::download_timeout,
   $nocheckcertificate = false,
+  $manage_logrotate   = true,
 ) inherits selenium::params {
   validate_string($user)
   validate_string($group)
@@ -24,6 +25,7 @@ class selenium(
   validate_string($url)
   validate_string($download_timeout)
   validate_bool($nocheckcertificate)
+  validate_bool($manage_logrotate)
 
   include wget
 
@@ -90,15 +92,17 @@ class selenium(
     require            => File[$jar_path],
   }
 
-  logrotate::rule { 'selenium':
-    path          => $log_path,
-    rotate_every  => 'weekly',
-    missingok     => true,
-    rotate        => '4',
-    compress      => true,
-    delaycompress => true,
-    copytruncate  => true,
-    minsize       => '100k',
+  if $manage_logrotate {
+    logrotate::rule { 'selenium':
+      path          => $log_path,
+      rotate_every  => 'weekly',
+      missingok     => true,
+      rotate        => '4',
+      compress      => true,
+      delaycompress => true,
+      copytruncate  => true,
+      minsize       => '100k',
+    }
   }
 
 }


### PR DESCRIPTION
- Make logrotation module dependency optional through a boolean as it might conflict with a different implementation. The user will need to use a wrapper module where they manage the logrotation there or rely on the upstream provided rotation file supplied by the package maintainer if present.

- Remove dependency on wget. All we need is a controlled exec and make sure Package['wget'] isn't managed in some other module.

- Allow installing selenium by package rather than through wget if the infrastructure has that capability and package available.

