### PR TITLE
Introduce dedicated jvm args parameter

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,6 +8,7 @@ define selenium::config(
   $group        = $selenium::params::group,
   $install_root = $selenium::params::install_root,
   $options      = $selenium::params::server_options,
+  $jvm_args     = $selenium::params::server_jvm_args,
   $java         = $selenium::params::java,
   $jar_name     = $selenium::jar_name,
 ) {

--- a/manifests/hub.pp
+++ b/manifests/hub.pp
@@ -5,7 +5,8 @@
 #
 #
 class selenium::hub(
-  $options = $selenium::params::hub_options,
+  $options  = $selenium::params::hub_options,
+  $jvm_args = $selenium::params::hub_jvm_args,
 ) inherits selenium::params {
   validate_string($options)
 
@@ -18,6 +19,7 @@ class selenium::hub(
     group        => $selenium::group,
     install_root => $selenium::install_root,
     options      => $options,
+    jvm_args     => $jvm_args,
     java         => $selenium::java,
   } ->
   anchor { 'selenium::hub::end': }

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -5,9 +5,10 @@
 #
 #
 class selenium::node(
-  $display = $selenium::params::display,
-  $options = $selenium::params::node_options,
-  $hub     = $selenium::params::default_hub,
+  $display  = $selenium::params::display,
+  $options  = $selenium::params::node_options,
+  $jvm_args = $selenium::params::node_jvm_args,
+  $hub      = $selenium::params::default_hub,
 ) inherits selenium::params {
   validate_string($display)
   validate_string($options)
@@ -25,6 +26,7 @@ class selenium::node(
     group        => $selenium::group,
     install_root => $selenium::install_root,
     options      => $safe_options,
+    jvm_args     => $jvm_args,
     java         => $selenium::java,
   } ->
   anchor { 'selenium::node::end': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,9 +10,12 @@ class selenium::params {
   $group            = $user
   $manage_group     = true
   $install_root     = '/opt/selenium'
-  $server_options   = '-Dwebdriver.enable.native.events=1'
+  $server_options   = ''
+  $server_jvm_args  = '-Dwebdriver.enable.native.events=1'
   $hub_options      = '-role hub'
-  $node_options     = "${server_options} -role node"
+  $hub_jvm_args     = ''
+  $node_options     = '-role node'
+  $node_jvm_args    = $server_jvm_args
   $java             = 'java'
   $version          = '2.45.0'
   $default_hub      = 'http://localhost:4444/grid/register'

--- a/spec/unit/classes/selenium_node_spec.rb
+++ b/spec/unit/classes/selenium_node_spec.rb
@@ -4,9 +4,10 @@ describe 'selenium::node', :type => :class do
 
   shared_examples 'node' do |params|
     p = {
-      :display => ':0',
-      :options => '-Dwebdriver.enable.native.events=1 -role node',
-      :hub     => 'http://localhost:4444/grid/register',
+      :display  => ':0',
+      :options  => '-role node',
+      :jvm_args => '-Dwebdriver.enable.native.events=1',
+      :hub      => 'http://localhost:4444/grid/register',
     }
 
     p.merge!(params) if params
@@ -15,6 +16,7 @@ describe 'selenium::node', :type => :class do
       should contain_class('selenium')
       should contain_selenium__config('node').with({
         'options' => "#{p[:options]} -hub #{p[:hub]}",
+        'jvm_args' => p[:jvm_args],
       })
       should contain_class('selenium::node')
     end

--- a/spec/unit/classes/selenium_server_spec.rb
+++ b/spec/unit/classes/selenium_server_spec.rb
@@ -4,8 +4,8 @@ describe 'selenium::server', :type => :class do
 
   shared_examples 'server' do |params|
     p = {
-      :display => ':0',
-      :options => '-Dwebdriver.enable.native.events=1',
+      :display  => ':0',
+      :jvm_args => '-Dwebdriver.enable.native.events=1',
     }
 
     p.merge!(params) if params
@@ -13,8 +13,8 @@ describe 'selenium::server', :type => :class do
     it do
       should contain_class('selenium')
       should contain_selenium__config('server').with({
-        'display' => p[:display],
-        'options' => p[:options],
+        'display'  => p[:display],
+        'jvm_args' => p[:jvm_args],
       })
       should contain_class('selenium::server')
     end

--- a/spec/unit/defines/selenium_config_spec.rb
+++ b/spec/unit/defines/selenium_config_spec.rb
@@ -11,7 +11,8 @@ describe 'selenium::config', :type => :define do
       :user         => 'selenium',
       :install_root => '/opt/selenium',
       :jar_name     => "selenium-server-standalone-#{DEFAULT_VERSION}.jar",
-      :options      => '-Dwebdriver.enable.native.events=1',
+      :options      => '',
+      :jvm_args     => '-Dwebdriver.enable.native.events=1',
       :java         => 'java',
     }
 
@@ -31,6 +32,7 @@ describe 'selenium::config', :type => :define do
         with_content(/SLNM_INSTALL_ROOT='#{p[:install_root]}'/).
         with_content(/SLNM_JAR_NAME='#{p[:jar_name]}'/).
         with_content(/SLNM_OPTIONS='#{p[:options]}'/).
+        with_content(/SLNM_JVM_ARGS='#{p[:jvm_args]}'/).
         with_content(/SLNM_JAVA='#{p[:java]}'/).
         with_content(/SLNM_LOG_NAME='#{title}'/).
         with_content(/prog='selenium#{title}'/)
@@ -59,7 +61,7 @@ describe 'selenium::config', :type => :define do
           :user         => 'Xselenium',
           :install_root => 'X/opt/selenium',
           :jar_name     => 'Xselenium-server-standalone-x.xx.x.jar',
-          :options      => 'X-Dwebdriver.enable.native.events=1',
+          :jvm_args     => 'X-Dwebdriver.enable.native.events=1',
           :java         => 'Xjava',
         }
 
@@ -82,7 +84,7 @@ describe 'selenium::config', :type => :define do
           :user         => 'Xselenium',
           :install_root => 'X/opt/selenium',
           :jar_name     => 'Xselenium-server-standalone-x.xx.x.jar',
-          :options      => 'X-Dwebdriver.enable.native.events=1',
+          :jvm_args     => 'X-Dwebdriver.enable.native.events=1',
           :java         => 'Xjava',
         }
 

--- a/templates/init.d/debian.selenium.erb
+++ b/templates/init.d/debian.selenium.erb
@@ -28,6 +28,7 @@ SELENIUM_LOG="${SELENIUM_INSTALL_ROOT}/log/${SELENIUM_LOG_NAME}_stdout.log"
 SELENIUM_ERROR_LOG="${SELENIUM_INSTALL_ROOT}/log/${SELENIUM_LOG_NAME}_stderr.log"
 SELENIUM_DISPLAY='<%= @display %>'
 SELENIUM_OPTIONS='<%= @options %>'
+SELENIUM_JVM_ARGS='<%= @jvm_args %>'
 HTTP_PORT=4444
 SELENIUM_ARGS="-port $HTTP_PORT"
 SELENIUM_JAVA='<%= @java %>'
@@ -103,7 +104,7 @@ do_start()
 
     # --user in daemon doesn't prepare environment variables like HOME, USER, LOGNAME or USERNAME,
     # so we let su do so for us now
-    $SU -l $SELENIUM_USER --shell=/bin/bash -c "$DAEMON $DAEMON_ARGS -- java -jar ${SELENIUM_JAR} ${SELENIUM_OPTIONS} > ${SELENIUM_LOG} 2> ${SELENIUM_ERROR_LOG}" || return 2
+    $SU -l $SELENIUM_USER --shell=/bin/bash -c "$DAEMON $DAEMON_ARGS -- java ${SELENIUM_JVM_ARGS} -jar ${SELENIUM_JAR} ${SELENIUM_OPTIONS} > ${SELENIUM_LOG} 2> ${SELENIUM_ERROR_LOG}" || return 2
 }
 
 #

--- a/templates/init.d/redhat.selenium.erb
+++ b/templates/init.d/redhat.selenium.erb
@@ -26,6 +26,7 @@ SLNM_DISPLAY='<%= @display %>'
 SLNM_USER='<%= @user %>'
 SLNM_INSTALL_ROOT='<%= @install_root %>'
 SLNM_JAR_NAME='<%= @jar_name %>'
+SLNM_JVM_ARGS='<%= @jvm_args %>'
 SLNM_OPTIONS='<%= @options %>'
 SLNM_JAVA='<%= @java %>'
 SLNM_LOG_NAME='<%= @name %>'
@@ -43,7 +44,7 @@ lockfile=/var/lock/subsys/$prog
 pidfile=/var/run/${prog}.pid
 
 # pidfile must be owned by selenium user
-exec="DISPLAY=${SLNM_DISPLAY} ${SLNM_JAVA} -jar ${SLNM_JAR} ${SLNM_OPTIONS} > ${SLNM_LOG} 2> ${SLNM_ERROR_LOG} & "'echo $!'" > ${pidfile}"
+exec="DISPLAY=${SLNM_DISPLAY} ${SLNM_JAVA} ${SLNM_JVM_ARGS} -jar ${SLNM_JAR} ${SLNM_OPTIONS} > ${SLNM_LOG} 2> ${SLNM_ERROR_LOG} & "'echo $!'" > ${pidfile}"
 
 start() {
 #    [ -x $exec ] || exit 5


### PR DESCRIPTION
Selenium tries to parse all parameters that come after -jar argument
on the command line. Meaning even system property settings like -Dkey=value
get in the way and become something like

Dwebdriver.chrome.driver=c:\selenium\chromedriver.exe:

Adding it prior -jar argument fixes this issue.
