### PR TITLE
Update logrotate module to yo61/logrotate

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,10 +7,10 @@ fixtures:
       repo: 'https://github.com/maestrodev/puppet-wget.git'
       ref: 'v1.2.2'
     logrotate:
-      repo: 'https://github.com/rodjek/puppet-logrotate.git'
+      repo: 'https://github.com/yo61/puppet-logrotate.git'
       # The current forge release (1.1.1) of logrotate is not compatible with
       # the future parser. See:
       # https://github.com/rodjek/puppet-logrotate/pull/39
-      ref: 'd569bcee1b43fa1af816c21afb5664d8e5235553'
+      ref: '499b74b577d9349e315cc27d68c8648d280fbcef'
   symlinks:
     selenium: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -495,4 +495,4 @@ See Also
  * [`puppetlabs-java`](https://github.com/puppetlabs/puppetlabs-java)
  * [`p0deje/display`](https://github.com/p0deje/puppet-display)
  * [`maestrodev/wget`](https://github.com/maestrodev/puppet-wget)
- * [`rodjek/logrotate`](https://github.com/rodjek/puppet-logrotate)
+ * [`yo61/logrotate`](https://github.com/yo61/puppet-logrotate)

--- a/metadata.json
+++ b/metadata.json
@@ -53,8 +53,8 @@
       "version_requirement": ">= 1.2.2 <2.0.0"
     },
     {
-      "name": "rodjek/logrotate",
-      "version_requirement": ">= 1.1.1 <2.0.0"
+      "name": "yo61/logrotate",
+      "version_requirement": "1.3.0"
     }
   ]
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -32,7 +32,7 @@ RSpec.configure do |c|
     hosts.each do |host|
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0, 1] }
       on host, puppet('module', 'install', 'maestrodev-wget'), { :acceptable_exit_codes => [0, 1] }
-      on host, puppet('module', 'install', 'rodjek-logrotate'), { :acceptable_exit_codes => [0, 1] }
+      on host, puppet('module', 'install', 'yo61-logrotate'), { :acceptable_exit_codes => [0, 1] }
       on host, puppet('module', 'install', 'puppetlabs-java'), { :acceptable_exit_codes => [0, 1] }
     end
   end


### PR DESCRIPTION
Please consider updating rodjek/logrotate module to a maintained fork yo61/logrotate.
New module have no problems with future parser.