### PR TITLE
[logrotate_rule_non_int]

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,7 +101,7 @@ class selenium(
       path          => $log_path,
       rotate_every  => 'weekly',
       missingok     => true,
-      rotate        => '4',
+      rotate        => 4,
       compress      => true,
       delaycompress => true,
       copytruncate  => true,


### PR DESCRIPTION
- changed the value 'rotate' in manifests/init.pp from STRING to INT as rodjek/puppet-logrotate requires
- form 'rodjek/puppet-logrotate':
  "rotate          - The Integer number of rotated log files to keep on disk
                (optional)."
- it causes an error on puppet 3.8 with parser=future
  
  modified:   manifests/init.pp
