### PR TITLE
Fixing port conflict on Debian

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,7 +9,7 @@ define selenium::config(
   $install_root = $selenium::params::install_root,
   $options      = $selenium::params::server_options,
   $java         = $selenium::params::java,
-  $port         = $selenium::params::port,
+  $port         = $selenium::params::default_port,
   $jar_name     = $selenium::jar_name,
   $classpath    = $selenium::params::default_classpath,
 ) {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,6 +9,7 @@ define selenium::config(
   $install_root = $selenium::params::install_root,
   $options      = $selenium::params::server_options,
   $java         = $selenium::params::java,
+  $port         = $selenium::params::port,
   $jar_name     = $selenium::jar_name,
   $classpath    = $selenium::params::default_classpath,
 ) {

--- a/manifests/hub.pp
+++ b/manifests/hub.pp
@@ -6,7 +6,7 @@
 #
 class selenium::hub(
   $options   = $selenium::params::hub_options,
-  $port      = $selenium::params::port,
+  $port      = $selenium::params::default_port,
   $classpath = $selenium::params::default_classpath,
 ) inherits selenium::params {
   validate_string($options)

--- a/manifests/hub.pp
+++ b/manifests/hub.pp
@@ -6,6 +6,7 @@
 #
 class selenium::hub(
   $options   = $selenium::params::hub_options,
+  $port      = $selenium::params::port,
   $classpath = $selenium::params::default_classpath,
 ) inherits selenium::params {
   validate_string($options)
@@ -19,6 +20,7 @@ class selenium::hub(
     group        => $selenium::group,
     install_root => $selenium::install_root,
     options      => $options,
+    port         => $port,
     java         => $selenium::java,
     classpath    => $classpath,
   } ->

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -8,6 +8,7 @@ class selenium::node(
   $display   = $selenium::params::display,
   $options   = $selenium::params::node_options,
   $hub       = $selenium::params::default_hub,
+  $port      = $selenium::params::port,
   $classpath = $selenium::params::default_classpath,
 ) inherits selenium::params {
   validate_string($display)
@@ -26,6 +27,7 @@ class selenium::node(
     group        => $selenium::group,
     install_root => $selenium::install_root,
     options      => $safe_options,
+    port         => $port,
     java         => $selenium::java,
     classpath    => $classpath
   } ->

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -8,7 +8,7 @@ class selenium::node(
   $display   = $selenium::params::display,
   $options   = $selenium::params::node_options,
   $hub       = $selenium::params::default_hub,
-  $port      = $selenium::params::port,
+  $port      = $selenium::params::default_port,
   $classpath = $selenium::params::default_classpath,
 ) inherits selenium::params {
   validate_string($display)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class selenium::params {
   $server_options   = '-Dwebdriver.enable.native.events=1'
   $hub_options      = '-role hub'
   $node_options     = "${server_options} -role node"
-  $port             = '4444'
+  $default_port     = '4444'
   $java             = 'java'
   $version          = '2.45.0'
   $default_hub      = 'http://localhost:4444/grid/register'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class selenium::params {
   $server_options   = '-Dwebdriver.enable.native.events=1'
   $hub_options      = '-role hub'
   $node_options     = "${server_options} -role node"
+  $port             = '4444'
   $java             = 'java'
   $version          = '2.45.0'
   $default_hub      = 'http://localhost:4444/grid/register'

--- a/templates/init.d/debian.selenium.erb
+++ b/templates/init.d/debian.selenium.erb
@@ -28,7 +28,7 @@ SELENIUM_LOG="${SELENIUM_INSTALL_ROOT}/log/${SELENIUM_LOG_NAME}_stdout.log"
 SELENIUM_ERROR_LOG="${SELENIUM_INSTALL_ROOT}/log/${SELENIUM_LOG_NAME}_stderr.log"
 SELENIUM_DISPLAY='<%= @display %>'
 SELENIUM_OPTIONS='<%= @options %>'
-HTTP_PORT=<%= @node_port %>
+HTTP_PORT=<%= @port %>
 SELENIUM_ARGS="-port $HTTP_PORT"
 SELENIUM_JAVA='<%= @java %>'
 SELENIUM_EXEC_COMMAND='<%= @exec_command %>'

--- a/templates/init.d/debian.selenium.erb
+++ b/templates/init.d/debian.selenium.erb
@@ -28,7 +28,7 @@ SELENIUM_LOG="${SELENIUM_INSTALL_ROOT}/log/${SELENIUM_LOG_NAME}_stdout.log"
 SELENIUM_ERROR_LOG="${SELENIUM_INSTALL_ROOT}/log/${SELENIUM_LOG_NAME}_stderr.log"
 SELENIUM_DISPLAY='<%= @display %>'
 SELENIUM_OPTIONS='<%= @options %>'
-HTTP_PORT=4444
+HTTP_PORT=<%= @node_port %>
 SELENIUM_ARGS="-port $HTTP_PORT"
 SELENIUM_JAVA='<%= @java %>'
 SELENIUM_EXEC_COMMAND='<%= @exec_command %>'


### PR DESCRIPTION
Making port a parameter, so it's possible to include both node and hub on the same host. Default port is 4444 as it was before. 