### PR TITLE
Fix wrong permissions of systemd unit file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,7 +47,7 @@ define selenium::config(
         path    => "/usr/lib/systemd/system/${prog}.service",
         owner   => 'root',
         group   => 'root',
-        mode    => '0755',
+        mode    => '0644',
         content => template("${module_name}/systemd/selenium.erb"),
       }
 


### PR DESCRIPTION
```
Configuration file /usr/lib/systemd/system/seleniumserver.service is marked executable. Please remove executable permission bits. Proceeding anyway.
```