### PR TITLE
initsystem param fix and amzn linux 1 compatibility

### DIFF
--- a/manifests/hub.pp
+++ b/manifests/hub.pp
@@ -22,6 +22,7 @@ class selenium::hub(
     options      => "${options} -log ${selenium::install_root}/log/seleniumhub.log",
     java         => $selenium::java,
     classpath    => $classpath,
+    initsystem   => $initsystem,
   }
     -> anchor { 'selenium::hub::end': }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,9 @@ class selenium::params {
         6: {
           $initsystem = 'init.d'
         }
+        2018: {
+          $initsystem = 'init.d'
+        }
         default: {
           $initsystem = 'systemd'
         }


### PR DESCRIPTION
stop hub.pp ignoring initsystem param, set 2018 major version to use init.d for Amazon Linux 1